### PR TITLE
Remove branch name so prod deploy actually deploys to prod

### DIFF
--- a/.github/workflows/deploy-pages-tspice-viewer.yml
+++ b/.github/workflows/deploy-pages-tspice-viewer.yml
@@ -52,7 +52,6 @@ jobs:
           command: >-
             pages deploy dist
             --project-name "${{ env.PAGES_PROJECT }}"
-            --branch main
 
   deploy-preview:
     name: Deploy preview (pull request)


### PR DESCRIPTION
Remove the branch name argument to pages deploy during the prod deployment so it is not treated as a preview deployment.