### PR TITLE
tspice v0.0.3: publishConfig + files allowlist

### DIFF
--- a/apps/tspice-viewer/package.json
+++ b/apps/tspice-viewer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rybosome/tspice-viewer",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/backend-contract/package.json
+++ b/packages/backend-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-backend-contract",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/backend-fake/package.json
+++ b/packages/backend-fake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-backend-fake",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/backend-node/package.json
+++ b/packages/backend-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-backend-node",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/backend-shim-c/package.json
+++ b/packages/backend-shim-c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-backend-shim-c",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/packages/backend-wasm/package.json
+++ b/packages/backend-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-backend-wasm",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-core",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/tspice-native-darwin-arm64/package.json
+++ b/packages/tspice-native-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-native-darwin-arm64",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "license": "MIT",
   "type": "commonjs",
   "main": "./index.js",

--- a/packages/tspice-native-darwin-x64/package.json
+++ b/packages/tspice-native-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-native-darwin-x64",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "license": "MIT",
   "type": "commonjs",
   "main": "./index.js",

--- a/packages/tspice-native-linux-x64-gnu/package.json
+++ b/packages/tspice-native-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice-native-linux-x64-gnu",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "license": "MIT",
   "type": "commonjs",
   "main": "./index.js",

--- a/packages/tspice/package.json
+++ b/packages/tspice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rybosome/tspice",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/tspice/package.json
+++ b/packages/tspice/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@rybosome/tspice",
   "version": "0.0.3",
-  "private": true,
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tspice/package.json
+++ b/packages/tspice/package.json
@@ -12,8 +12,13 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:dist-publish": "node ./scripts/build-dist-publish.mjs",


### PR DESCRIPTION
- Bump `@rybosome/tspice` version to `0.0.3` and make package publishable
- Add `publishConfig.access=public`
- Add `files` allowlist to control published tarball contents (`dist`, `README.md`, `LICENSE`)