### PR TITLE
docs(readme): clarify SPICE context and add browser + Node quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,7 @@ import { kernels, spiceClients } from "@rybosome/tspice";
 
 async function main() {
   // We can download kernels directly from NAIF servers in Node.
-  const kernelPack = kernels
-    .naif({
-      origin: "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/",
-      pathBase: "naif/",
-    })
+  const kernelPack = kernels.naif()
     .pick(
       "lsk/naif0012.tls",
       "pck/pck00011.tpc",


### PR DESCRIPTION
## Summary
Improve the README so the PR accurately describes `tspice`, and provide clearer quickstart guidance across browser and Node runtimes.

## What changed
- Clarified the project intro around NASA/NAIF SPICE terminology and reordered the intro paragraphs for readability.
- Expanded and tightened `Why tspice` comparisons with CSPICE, SpiceyPy, and ANISE.
- Refined wording around how `tspice` relates to CSPICE.
- Restructured quickstart into explicit sections for installation, browser (WASM), and Node.
- Added kernel-hosting guidance plus concrete `kernels.naif(...)` and `kernels.custom(...)` examples.
- Added a Node example using `spiceClients ... toSync({ backend: "node" })`.

## Why
The README changes make onboarding clearer, better explain where `tspice` fits in the SPICE ecosystem, and give runnable examples for both browser and Node users.

## Testing
Not run (README/docs-only changes).
